### PR TITLE
add PyYAML to setup.py install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(
     url='http://www.intel.com',
     packages=find_packages(),
     install_requires=['sawtooth-core', 'cbor>=0.1.23', 'colorlog',
-                      'twisted'],
+                      'twisted', 'PyYAML'],
     data_files=data_files,
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
```sawtooth-validator``` requires ```PyYAML``` 

It is installed by ```sawtooth-dev-tools``` but was not included in the ```install_requires``` of ```setup.py```
