### PR TITLE
set default wait times for small networks

### DIFF
--- a/etc/txnvalidator.js.example
+++ b/etc/txnvalidator.js.example
@@ -18,9 +18,14 @@
     "GenesisLedger" : false,
 
     ## configuration of the ledger wait time certificate 
-    "TargetWaitTime" : 30.0,
-    "InitialWaitTime" : 750.0,
+    ## suggested settings for single node dev environment
+    "TargetWaitTime" : 5.0,
+    "InitialWaitTime" : 5.0,
     "CertificateSampleLength" : 30,
+
+    ## suggested settings for a 25 node network
+    ## "TargetWaitTime" : 30.0,
+    ## "InitialWaitTime" : 750.0,
 
     ## configuration of the block sizes
     "MinTransactionsPerBlock" : 1,

--- a/txnserver/config.py
+++ b/txnserver/config.py
@@ -299,8 +299,8 @@ class ValidatorDefaultConfig(sawtooth.config.Config):
         self['Restore'] = False
 
         # configuration of the ledger wait time certificate
-        self['TargetWaitTime'] = 30.0
-        self['InitialWaitTime'] = 750.0
+        self['TargetWaitTime'] = 5.0
+        self['InitialWaitTime'] = 5.0
         self['CertificateSampleLength'] = 30
 
         # configuration of the block sizes


### PR DESCRIPTION
These defaults are appropriate for developers experimenting on small
networks.
Suggested settings are added as comments to the config files for those
experimenting on larger networks.