### PR TITLE
psutil was missing as install requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ setup(
     url='http://www.intel.com',
     packages=find_packages(),
     install_requires=['sawtooth-core', 'cbor>=0.1.23', 'colorlog',
-                      'twisted', 'PyYAML'],
+                      'twisted', 'PyYAML', 'psutil'],
     data_files=data_files,
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Signed-off-by: Bas van Oostveen trbs@trbs.net
